### PR TITLE
Refactor ParseISO8601D to handle int64 overflow better

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
-	github.com/JohnCGriffin/overflow v0.0.0-20170615021017-4d914c927216
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/JohnCGriffin/overflow v0.0.0-20170615021017-4d914c927216 h1:2ZboyJ8vl75fGesnG9NpMTD2DyQI3FzMXy4x752rGF0=
-github.com/JohnCGriffin/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/Microsoft/go-winio v0.4.12 h1:xAfWHN1IrQ0NJ9TBC0KBZoqLjzDTr1ML+4MywiUOryc=
 github.com/Microsoft/go-winio v0.4.12/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
@@ -51,6 +49,7 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/pkg/time/parse.go
+++ b/pkg/time/parse.go
@@ -22,7 +22,19 @@ const (
 	// Year duration
 	Year = (time.Duration(365.2425*float64(Day)) / time.Second) * time.Second // truncate to second
 
-	iso8601Group        = `(?:(?P<%s>-?\d+(?:[,.]\d+)?)%s)?`
+	// ISO 8601 Duration string parts
+	iso8601Weeks   = "W"
+	iso8601Years   = "Y"
+	iso8601Months  = "M"
+	iso8601Days    = "D"
+	iso8601Hours   = "H"
+	iso8601Minutes = "M"
+	iso8601Seconds = "S"
+
+	// ISO 8601 duration string part regexp pattern
+	iso8601Group = `(?:(?P<%s>-?\d+(?:[,.]\d+)?)%s)?`
+
+	// ISO 8601 duration string regexp group names
 	iso8601GroupWeeks   = "W"
 	iso8601GroupYears   = "Y"
 	iso8601GroupMonths  = "m"
@@ -33,14 +45,14 @@ const (
 )
 
 var iso8601Duration = regexp.MustCompile(fmt.Sprintf(`^P(?:0|%s|%s)$`,
-	fmt.Sprintf(iso8601Group, iso8601GroupWeeks, "W"),
+	fmt.Sprintf(iso8601Group, iso8601GroupWeeks, iso8601Weeks),
 	fmt.Sprintf(`%s%s%s(?:T%s%s%s)?`,
-		fmt.Sprintf(iso8601Group, iso8601GroupYears, "Y"),
-		fmt.Sprintf(iso8601Group, iso8601GroupMonths, "M"),
-		fmt.Sprintf(iso8601Group, iso8601GroupDays, "D"),
-		fmt.Sprintf(iso8601Group, iso8601GroupHours, "H"),
-		fmt.Sprintf(iso8601Group, iso8601GroupMinutes, "M"),
-		fmt.Sprintf(iso8601Group, iso8601GroupSeconds, "S"),
+		fmt.Sprintf(iso8601Group, iso8601GroupYears, iso8601Years),
+		fmt.Sprintf(iso8601Group, iso8601GroupMonths, iso8601Months),
+		fmt.Sprintf(iso8601Group, iso8601GroupDays, iso8601Days),
+		fmt.Sprintf(iso8601Group, iso8601GroupHours, iso8601Hours),
+		fmt.Sprintf(iso8601Group, iso8601GroupMinutes, iso8601Minutes),
+		fmt.Sprintf(iso8601Group, iso8601GroupSeconds, iso8601Seconds),
 	),
 ))
 

--- a/pkg/time/parse.go
+++ b/pkg/time/parse.go
@@ -1,14 +1,12 @@
 package time
 
 import (
+	"errors"
 	"fmt"
-	"math"
+	"math/big"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
-
-	"github.com/JohnCGriffin/overflow" // Detect int/float overflow problems
 )
 
 const (
@@ -23,25 +21,35 @@ const (
 
 	// Year duration
 	Year = (time.Duration(365.2425*float64(Day)) / time.Second) * time.Second // truncate to second
+
+	iso8601Group        = `(?:(?P<%s>-?\d+(?:[,.]\d+)?)%s)?`
+	iso8601GroupWeeks   = "W"
+	iso8601GroupYears   = "Y"
+	iso8601GroupMonths  = "m"
+	iso8601GroupDays    = "d"
+	iso8601GroupHours   = "H"
+	iso8601GroupMinutes = "M"
+	iso8601GroupSeconds = "S"
 )
 
-const iso8601Group = `(?:(?P<%s>-?\d+(?:[,.]\d+)?)%s)?`
-
 var iso8601Duration = regexp.MustCompile(fmt.Sprintf(`^P(?:0|%s|%s)$`,
-	fmt.Sprintf(iso8601Group, "weeks", "W"),
+	fmt.Sprintf(iso8601Group, iso8601GroupWeeks, "W"),
 	fmt.Sprintf(`%s%s%s(?:T%s%s%s)?`,
-		fmt.Sprintf(iso8601Group, "years", "Y"),
-		fmt.Sprintf(iso8601Group, "months", "M"),
-		fmt.Sprintf(iso8601Group, "days", "D"),
-		fmt.Sprintf(iso8601Group, "hours", "H"),
-		fmt.Sprintf(iso8601Group, "minutes", "M"),
-		fmt.Sprintf(iso8601Group, "seconds", "S"),
+		fmt.Sprintf(iso8601Group, iso8601GroupYears, "Y"),
+		fmt.Sprintf(iso8601Group, iso8601GroupMonths, "M"),
+		fmt.Sprintf(iso8601Group, iso8601GroupDays, "D"),
+		fmt.Sprintf(iso8601Group, iso8601GroupHours, "H"),
+		fmt.Sprintf(iso8601Group, iso8601GroupMinutes, "M"),
+		fmt.Sprintf(iso8601Group, iso8601GroupSeconds, "S"),
 	),
 ))
 
+// ErrInt64Overflow is returned by ParseISO8601D if the duration can't fit in an int64.
+var ErrInt64Overflow = errors.New("int64 overflow")
+
 // ParseISO8601D parses an ISO 8601 duration string.
 // Errors are returned if the string can't be parsed or the duration
-// overflows int64.
+// overflows an int64.
 //
 // The following time assumptions are used:
 // - Days are 24 hours.
@@ -52,52 +60,61 @@ var iso8601Duration = regexp.MustCompile(fmt.Sprintf(`^P(?:0|%s|%s)$`,
 // See: https://en.wikipedia.org/wiki/ISO_8601#Durations
 func ParseISO8601D(duration string) (time.Duration, error) {
 	if duration == "" {
-		return 0, fmt.Errorf("cannot parse a blank string as a period")
+		return 0, fmt.Errorf("cannot parse a blank string as a duration")
 	}
-
 	if duration == "P0" {
 		return 0, nil
 	}
-
 	matches := iso8601Duration.FindStringSubmatch(duration)
 	if matches == nil {
-		return 0, fmt.Errorf("cannot parse Period string")
+		return 0, fmt.Errorf("cannot parse duration string")
 	}
 	groupNames := iso8601Duration.SubexpNames()
-	var d time.Duration
+	const precision = 128 // Arbitrary number bigger than an int64
+	sum := new(big.Float).SetPrec(precision)
 	for i := 1; i < len(groupNames); i++ {
 		group, match := groupNames[i], matches[i]
 		if match == "" {
 			continue
 		}
-		n, err := strconv.ParseFloat(strings.Replace(match, ",", ".", 1), 64)
+		n, _, err := big.ParseFloat(
+			strings.Replace(match, ",", ".", 1), // Convert comma decimal separator to period.
+			10,
+			precision,
+			big.ToZero,
+		)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse %s value '%s': %v", group, match, err)
 		}
-		var r time.Duration
-		var ok bool
+		var d time.Duration
 		switch group {
-		case "weeks":
-			r, ok = addDurationMul(d, n, Week)
-		case "years":
-			r, ok = addDurationMul(d, n, Year)
-		case "months":
-			r, ok = addDurationMul(d, n, Month)
-		case "days":
-			r, ok = addDurationMul(d, n, Day)
-		case "hours":
-			r, ok = addDurationMul(d, n, time.Hour)
-		case "minutes":
-			r, ok = addDurationMul(d, n, time.Minute)
-		case "seconds":
-			r, ok = addDurationMul(d, n, time.Second)
+		case iso8601GroupWeeks:
+			d = Week
+		case iso8601GroupYears:
+			d = Year
+		case iso8601GroupMonths:
+			d = Month
+		case iso8601GroupDays:
+			d = Day
+		case iso8601GroupHours:
+			d = time.Hour
+		case iso8601GroupMinutes:
+			d = time.Minute
+		case iso8601GroupSeconds:
+			d = time.Second
 		}
-		if !ok {
-			return r, fmt.Errorf("int64 overflow")
-		}
-		d = r
+		bigD := new(big.Float).SetInt64(int64(d))
+		n = n.Mul(n, bigD)
+		sum = sum.Add(sum, n)
 	}
-	return d, nil
+	switch i, a := sum.Int64(); a {
+	case big.Below, big.Above:
+		return time.Duration(i), ErrInt64Overflow
+	case big.Exact:
+		return time.Duration(i), nil
+	default:
+		panic("unknown accuracy: " + a.String())
+	}
 }
 
 // MustParseISO8601D is like ParseISO8601D, but panics if there's an error.
@@ -107,16 +124,4 @@ func MustParseISO8601D(duration string) time.Duration {
 		panic(err)
 	}
 	return d
-}
-
-// addDurationMul returns d + (n * u), and a bool indicating there was no int64 overflow/underflow.
-func addDurationMul(d time.Duration, n float64, u time.Duration) (time.Duration, bool) {
-	r := n * float64(u)
-	if r > float64(math.MaxInt64) {
-		return time.Duration(math.MaxInt64), false
-	} else if r < float64(math.MinInt64) {
-		return time.Duration(math.MinInt64), false
-	}
-	i, ok := overflow.Add64(int64(d), int64(r))
-	return time.Duration(i), ok
 }

--- a/pkg/time/parse_test.go
+++ b/pkg/time/parse_test.go
@@ -1,6 +1,7 @@
 package time
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ func TestParseISO8601D(t *testing.T) {
 		desc string
 		in   string
 		want time.Duration
+		err  error
 	}{
 		{
 			desc: "zero",
@@ -55,16 +57,27 @@ func TestParseISO8601D(t *testing.T) {
 		},
 		{
 			desc: "complex",
-			in:   "P10Y5M3DT14H12M8S",
-			want: 10*Year + 5*Month + 3*Day + 14*time.Hour + 12*time.Minute + 8*time.Second,
+			in:   "P10Y5M-3DT14H12M8S",
+			want: 10*Year + 5*Month - 3*Day + 14*time.Hour + 12*time.Minute + 8*time.Second,
+		},
+		{
+			desc: "overflow-positive",
+			in:   "P292Y3M9DT20H53M35S",
+			want: time.Duration(math.MaxInt64),
+			err:  ErrInt64Overflow,
+		},
+		{
+			desc: "overflow-negative",
+			in:   "P-292Y-3M-9DT-20H-53M-35S",
+			want: time.Duration(math.MinInt64),
+			err:  ErrInt64Overflow,
 		},
 	}
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			got, err := ParseISO8601D(tC.in)
-			if assert.NoError(t, err) {
-				assert.Equal(t, tC.want, got)
-			}
+			assert.Equal(t, tC.err, err)
+			assert.Equal(t, tC.want, got)
 		})
 	}
 }


### PR DESCRIPTION
@chavlin
This PR eliminates int overflow edge cases for `pkg/time.ParseISO8601D()` by using the [`math/big`](https://golang.org/pkg/math/big/) package to parse Durations that can't fit in an int64.