### PR TITLE
Refactor pkg/time.Between to handle out-of-order args

### DIFF
--- a/pkg/time/comp.go
+++ b/pkg/time/comp.go
@@ -2,7 +2,10 @@ package time
 
 import "time"
 
-// Between returns true if t is between start and end inclusive.
-func Between(t, start, end time.Time) bool {
-	return (start.Equal(t) || start.Before(t)) && (end.Equal(t) || end.After(t))
+// Between returns true if t is between a and b inclusive.
+func Between(t, a, b time.Time) bool {
+	if b.Before(a) {
+		a, b = b, a
+	}
+	return (a.Equal(t) || a.Before(t)) && (b.Equal(t) || b.After(t))
 }

--- a/pkg/time/comp_test.go
+++ b/pkg/time/comp_test.go
@@ -1,8 +1,13 @@
 package time
 
 import (
+	"math/rand"
+	"reflect"
 	"testing"
+	"testing/quick"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBetween(t *testing.T) {
@@ -64,9 +69,37 @@ func TestBetween(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Between(tt.args.t, tt.args.start, tt.args.end); got != tt.want {
-				t.Errorf("Between() = %v, want %v", got, tt.want)
-			}
+			got := Between(tt.args.t, tt.args.start, tt.args.end)
+			assert.Equal(t, tt.want, got,
+				"Between(%s, %s, %s) = %v, want %v", tt.args.t, tt.args.start, tt.args.end, got, tt.want,
+			)
 		})
 	}
+
+	// Check that Between(t, a, b) == Between(t, b, a).
+	t.Run("args-order", func(t *testing.T) {
+		reversedBetween := func(t, a, b time.Time) bool {
+			return Between(t, b, a)
+		}
+
+		err := quick.CheckEqual(Between, reversedBetween, &quick.Config{
+			Values: func(args []reflect.Value, r *rand.Rand) {
+				randomTime := func() time.Time {
+					sec := r.Int63()
+					if r.Float64() > 0.5 {
+						sec = -sec
+					}
+					nsec := r.Int63()
+					if r.Float64() > 0.5 {
+						nsec = -nsec
+					}
+					return time.Unix(sec, nsec)
+				}
+				args[0] = reflect.ValueOf(randomTime()) // t
+				args[1] = reflect.ValueOf(randomTime()) // a
+				args[2] = reflect.ValueOf(randomTime()) // b
+			},
+		})
+		assert.NoError(t, err)
+	})
 }


### PR DESCRIPTION
@chavlin
This PR refactors `pkg/time.Between` to take its second and third args in any order e.g.
```go
a := time.Now()
now := time.Now()
b := time.Now()
Between(now, a, b) == Between(now, b, a)
```